### PR TITLE
feat: support new method variant schema

### DIFF
--- a/src/features/methods/MethodsList.tsx
+++ b/src/features/methods/MethodsList.tsx
@@ -27,15 +27,30 @@ export function MethodsList({ username }: { username: string }) {
 
   const rows =
     data?.flatMap((method) =>
-      method.variants.map((variant) => {
-        const levels = variant.requirements?.levels || {};
+      method.variants.map((variant, index) => {
+        const levels = Array.isArray(variant.requirements?.levels)
+          ? variant.requirements!.levels
+          : Object.entries(variant.requirements?.levels || {}).map(
+              ([skill, level]) => ({
+                skill,
+                level: Number(level),
+              })
+            );
+
+        const xpHour = Array.isArray(variant.xpHour)
+          ? variant.xpHour
+          : Object.entries(variant.xpHour || {}).map(([skill, experience]) => ({
+              skill,
+              experience: Number(experience),
+            }));
+
         return {
-          id: `${method.id}-${variant.id}`,
+          id: `${method.id}-${variant.id ?? index}`,
           methodId: method.id,
           name: method.name,
           category: method.category,
           label: variant.label,
-          xpHour: variant.xpHour || {},
+          xpHour,
           clickIntensity: variant.clickIntensity,
           afkiness: variant.afkiness,
           riskLevel: variant.riskLevel,
@@ -77,16 +92,16 @@ export function MethodsList({ username }: { username: string }) {
               <TableCell>{row.category}</TableCell>
               <TableCell>{row.label}</TableCell>
               <TableCell>
-                {Object.entries(row.xpHour).map(([skill, xp]) => (
-                  <div key={skill}>{`${skill}: ${xp}`}</div>
+                {row.xpHour.map(({ skill, experience }) => (
+                  <div key={skill}>{`${skill}: ${experience}`}</div>
                 ))}
               </TableCell>
               <TableCell>{row.clickIntensity}</TableCell>
               <TableCell>{row.afkiness}</TableCell>
               <TableCell>{row.riskLevel}</TableCell>
               <TableCell>
-                {Object.entries(row.levels).map(([skill, lvl]) => (
-                  <div key={skill}>{`${skill}: ${lvl}`}</div>
+                {row.levels.map(({ skill, level }) => (
+                  <div key={skill}>{`${skill}: ${level}`}</div>
                 ))}
               </TableCell>
             </TableRow>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,34 +8,52 @@ export interface Method {
   variants: Variant[];
 }
 
+type ItemRequirement = {
+  id: number;
+  quantity: number;
+  reason?: string;
+};
+
+type LevelRequirement = {
+  skill: string;
+  level: number;
+  reason?: string;
+};
+
+type QuestRequirement = {
+  name: string;
+  stage: number;
+  reason?: string;
+};
+
+type DiaryRequirement = {
+  name: string;
+  stage: number;
+  reason?: string;
+};
+
 type Requirement = {
-  items: { id: number; quantity: number }[];
-  levels: Record<string, number>;
-  quests: Record<string, number>;
-  achievement_diaries: Record<string, number>;
+  items?: ItemRequirement[];
+  levels?: LevelRequirement[];
+  quests?: QuestRequirement[];
+  achievement_diaries?: DiaryRequirement[];
 };
 
 export interface Variant {
-  id: string;
+  id?: string;
   label: string;
-  afkiness: number;
-  clickIntensity: number;
-  riskLevel: string;
-  xpHour: Record<string, number>;
-  requirements: Requirement;
-  recommendations: Requirement;
-  highProfit: number;
-  lowProfit: number;
-  missingRequirements?: {
-    items: { id: number; quantity: number }[];
-    levels: Record<string, number>;
-    quests: Record<string, number>;
-    achievement_diaries: Record<string, number>;
-  };
-
-  inputs: { id: string; quantity: number }[];
-  outputs: { id: string; quantity: number }[];
   description?: string;
+  afkiness?: number;
+  clickIntensity?: number;
+  riskLevel?: string;
+  xpHour?: { skill: string; experience: number }[];
+  requirements: Requirement;
+  recommendations?: Requirement;
+  highProfit?: number;
+  lowProfit?: number;
+  missingRequirements?: { id: number; name: string; level: number }[];
+  inputs: { id: number; quantity: number }[];
+  outputs: { id: number; quantity: number }[];
 }
 
 export async function fetchMethods(username?: string): Promise<Method[]> {
@@ -47,5 +65,88 @@ export async function fetchMethods(username?: string): Promise<Method[]> {
     throw new Error(`HTTP ${res.status} – Error fetching methods`);
   }
   const json = await res.json();
-  return json.data;
+
+  const normalizeXpHour = (
+    xp: unknown
+  ): { skill: string; experience: number }[] =>
+    Array.isArray(xp)
+      ? xp
+      : xp && typeof xp === "object"
+      ? Object.entries(xp as Record<string, number>).map(
+          ([skill, experience]) => ({
+            skill,
+            experience: Number(experience),
+          })
+        )
+      : [];
+
+  const normalizeLevels = (levels: unknown): LevelRequirement[] =>
+    Array.isArray(levels)
+      ? levels
+      : levels && typeof levels === "object"
+      ? Object.entries(levels as Record<string, number>).map(
+          ([skill, level]) => ({
+            skill,
+            level: Number(level),
+          })
+        )
+      : [];
+
+  const normalizeQuests = (quests: unknown): QuestRequirement[] =>
+    Array.isArray(quests)
+      ? quests
+      : quests && typeof quests === "object"
+      ? Object.entries(quests as Record<string, number>).map(
+          ([name, stage]) => ({
+            name,
+            stage: Number(stage),
+          })
+        )
+      : [];
+
+  const normalizeDiaries = (diaries: unknown): DiaryRequirement[] =>
+    Array.isArray(diaries)
+      ? diaries
+      : diaries && typeof diaries === "object"
+      ? Object.entries(diaries as Record<string, number>).map(
+          ([name, stage]) => ({
+            name,
+            stage: Number(stage),
+          })
+        )
+      : [];
+
+  const normalizeRequirement = (req: unknown): Requirement => {
+    if (!req || typeof req !== "object") {
+      return {
+        items: [],
+        levels: [],
+        quests: [],
+        achievement_diaries: [],
+      };
+    }
+    const r = req as {
+      items?: ItemRequirement[];
+      levels?: unknown;
+      quests?: unknown;
+      achievement_diaries?: unknown;
+    };
+    return {
+      items: r.items ?? [],
+      levels: normalizeLevels(r.levels),
+      quests: normalizeQuests(r.quests),
+      achievement_diaries: normalizeDiaries(r.achievement_diaries),
+    };
+  };
+
+  const methods = json.data as Method[];
+  return methods.map((method) => ({
+    ...method,
+    variants: method.variants.map((v) => ({
+      ...v,
+      xpHour: normalizeXpHour(v.xpHour),
+      requirements: normalizeRequirement(v.requirements),
+      recommendations: normalizeRequirement(v.recommendations),
+    })),
+  }));
 }

--- a/src/pages/MethodDetail.tsx
+++ b/src/pages/MethodDetail.tsx
@@ -53,14 +53,21 @@ export function MethodDetail() {
 
       <Tabs className="w-full">
         <TabsList>
-          {data.variants.map((variant: Variant) => (
-            <TabsTrigger key={variant.id} value={variant.id}>
+          {data.variants.map((variant: Variant, index: number) => (
+            <TabsTrigger
+              key={variant.id ?? index.toString()}
+              value={variant.id ?? index.toString()}
+            >
               {variant.label}
             </TabsTrigger>
           ))}
         </TabsList>
-        {data.variants.map((variant: Variant) => (
-          <TabsContent key={variant.id} value={variant.id} className="p-4">
+        {data.variants.map((variant: Variant, index: number) => (
+          <TabsContent
+            key={variant.id ?? index.toString()}
+            value={variant.id ?? index.toString()}
+            className="p-4"
+          >
             {/* <div className="mb-2">
               <span className="font-semibold">AFKiness:</span>{" "}
               {variant.afkiness}
@@ -251,75 +258,8 @@ export function MethodDetail() {
                                 </h3>
                                 <div className="mt-3 min-h-14 w-full rounded bg-gray-300">
                                   <div className="flex flex-col gap-2">
-                                    {Object.entries(
-                                      variant.requirements.levels
-                                    ).map(([skill, level]) => (
-                                      <Badge
-                                        size="lg"
-                                        key={skill}
-                                        variant="secondary"
-                                      >
-                                        <img
-                                          src={getUrlByType(skill) ?? ""}
-                                          alt={`${skill.toLowerCase()}_icon`}
-                                          title={`${skill}`}
-                                        />
-                                        {level}
-                                      </Badge>
-                                    ))}
-                                    {Object.entries(
-                                      variant.requirements.quests
-                                    ).map(([quest, stage]) => (
-                                      <Badge
-                                        size="lg"
-                                        key={quest}
-                                        variant="secondary"
-                                      >
-                                        <img
-                                          src={getUrlByType("quests") ?? ""}
-                                          alt={`quests_icon`}
-                                          title="quests"
-                                        />
-                                        {stage === 1
-                                          ? quest
-                                          : `${quest} (started)`}
-                                      </Badge>
-                                    ))}
-                                    {Object.entries(
-                                      variant.requirements.achievement_diaries
-                                    ).map(([achievement_diary, stage]) => (
-                                      <Badge
-                                        size="lg"
-                                        key={`${achievement_diary}_${stage}`}
-                                        variant="secondary"
-                                      >
-                                        <img
-                                          src={
-                                            getUrlByType(
-                                              "achivement_diaries"
-                                            ) ?? ""
-                                          }
-                                          alt={`achivements_diaries_icon`}
-                                          title="quests"
-                                        />
-                                        {`${achievement_diary} ${getAchivementDiaryStageByLevel(
-                                          stage
-                                        )}`}
-                                      </Badge>
-                                    ))}
-                                  </div>
-                                </div>
-                              </div>
-                              {variant.recommendations && (
-                                <div className="mt-8">
-                                  <h3 className="text-sm font-semibold">
-                                    Recommendations
-                                  </h3>
-                                  <div className="mt-3 min-h-14 w-full rounded bg-gray-300">
-                                    <div className="flex flex-col gap-2">
-                                      {Object.entries(
-                                        variant.recommendations.levels
-                                      ).map(([skill, level]) => (
+                                    {(variant.requirements?.levels || []).map(
+                                      ({ skill, level }) => (
                                         <Badge
                                           size="lg"
                                           key={skill}
@@ -332,13 +272,13 @@ export function MethodDetail() {
                                           />
                                           {level}
                                         </Badge>
-                                      ))}
-                                      {Object.entries(
-                                        variant.recommendations.quests
-                                      ).map(([quest, stage]) => (
+                                      )
+                                    )}
+                                    {(variant.requirements?.quests || []).map(
+                                      ({ name, stage }) => (
                                         <Badge
                                           size="lg"
-                                          key={quest}
+                                          key={name}
                                           variant="secondary"
                                         >
                                           <img
@@ -347,17 +287,16 @@ export function MethodDetail() {
                                             title="quests"
                                           />
                                           {stage === 1
-                                            ? quest
-                                            : `${quest} (started)`}
+                                            ? name
+                                            : `${name} (started)`}
                                         </Badge>
-                                      ))}
-                                      {Object.entries(
-                                        variant.recommendations
-                                          .achievement_diaries
-                                      ).map(([achievement_diary, stage]) => (
+                                      )
+                                    )}
+                                    {(variant.requirements?.achievement_diaries || []).map(
+                                      ({ name, stage }) => (
                                         <Badge
                                           size="lg"
-                                          key={`${achievement_diary}_${stage}`}
+                                          key={`${name}_${stage}`}
                                           variant="secondary"
                                         >
                                           <img
@@ -369,11 +308,78 @@ export function MethodDetail() {
                                             alt={`achivements_diaries_icon`}
                                             title="quests"
                                           />
-                                          {`${achievement_diary} ${getAchivementDiaryStageByLevel(
+                                          {`${name} ${getAchivementDiaryStageByLevel(
                                             stage
                                           )}`}
                                         </Badge>
-                                      ))}
+                                      )
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
+                              {variant.recommendations && (
+                                <div className="mt-8">
+                                  <h3 className="text-sm font-semibold">
+                                    Recommendations
+                                  </h3>
+                                  <div className="mt-3 min-h-14 w-full rounded bg-gray-300">
+                                    <div className="flex flex-col gap-2">
+                                      {(variant.recommendations?.levels || []).map(
+                                        ({ skill, level }) => (
+                                          <Badge
+                                            size="lg"
+                                            key={skill}
+                                            variant="secondary"
+                                          >
+                                            <img
+                                              src={getUrlByType(skill) ?? ""}
+                                              alt={`${skill.toLowerCase()}_icon`}
+                                              title={`${skill}`}
+                                            />
+                                            {level}
+                                          </Badge>
+                                        )
+                                      )}
+                                      {(variant.recommendations?.quests || []).map(
+                                        ({ name, stage }) => (
+                                          <Badge
+                                            size="lg"
+                                            key={name}
+                                            variant="secondary"
+                                          >
+                                            <img
+                                              src={getUrlByType("quests") ?? ""}
+                                              alt={`quests_icon`}
+                                              title="quests"
+                                            />
+                                            {stage === 1
+                                              ? name
+                                              : `${name} (started)`}
+                                          </Badge>
+                                        )
+                                      )}
+                                      {(variant.recommendations?.achievement_diaries || []).map(
+                                        ({ name, stage }) => (
+                                          <Badge
+                                            size="lg"
+                                            key={`${name}_${stage}`}
+                                            variant="secondary"
+                                          >
+                                            <img
+                                              src={
+                                                getUrlByType(
+                                                  "achivement_diaries"
+                                                ) ?? ""
+                                              }
+                                              alt={`achivements_diaries_icon`}
+                                              title="quests"
+                                            />
+                                            {`${name} ${getAchivementDiaryStageByLevel(
+                                              stage
+                                            )}`}
+                                          </Badge>
+                                        )
+                                      )}
                                     </div>
                                   </div>
                                 </div>


### PR DESCRIPTION
## Summary
- normalize variant xp/hour and requirement structures when fetching methods
- convert legacy requirement and xp/hour objects to arrays in methods table to avoid crashes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@radix-ui/react-accordion' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a2375e7e48832f895bc16c0c945f5c