### PR TITLE
Fix/item search autoload more results

### DIFF
--- a/src/components/requirements-recommendations/useRequirementsRecommendations.ts
+++ b/src/components/requirements-recommendations/useRequirementsRecommendations.ts
@@ -448,6 +448,37 @@ export function useRequirementsRecommendations({
     ]
   );
 
+  useEffect(() => {
+    const hasOnlyItemOptions =
+      itemSearchOptions.length > 0 &&
+      questSearchOptions.length === 0 &&
+      achievementDiarySearchOptions.length === 0 &&
+      skillSearchOptions.length === 0;
+
+    if (
+      !trimmedQuery ||
+      itemSearchLoading ||
+      itemSearchLoadingMore ||
+      !itemSearchHasMore ||
+      !hasOnlyItemOptions ||
+      itemSearchOptions.length > ITEM_SEARCH_LIMIT
+    ) {
+      return;
+    }
+
+    loadMoreItemSearchResults();
+  }, [
+    achievementDiarySearchOptions.length,
+    itemSearchHasMore,
+    itemSearchLoading,
+    itemSearchLoadingMore,
+    itemSearchOptions.length,
+    loadMoreItemSearchResults,
+    questSearchOptions.length,
+    skillSearchOptions.length,
+    trimmedQuery,
+  ]);
+
   const emptyMessage = trimmedQuery ? "Sin resultados" : "Escribe para buscar";
 
   const updateEntry = useCallback(


### PR DESCRIPTION
## Summary
- Auto-loads additional item search results when a query currently returns only item options and more item pages are available.
- Prevents unnecessary extra loads by guarding on active query state, loading flags, and option thresholds.

## How to test
```powershell
npm run lint
$env:CI='true'; npm test
npm run build
```
- In the requirements recommendations search, type a query that returns item matches only and confirm additional item results are loaded automatically.

## Notes
- No API contract changes.
