### PR TITLE
refactor(notice): standardize username fetch notice states and UX

### DIFF
--- a/src/components/UsernameFetchNotice.tsx
+++ b/src/components/UsernameFetchNotice.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useState, type ReactNode } from "react";
-import { IconInfoCircle, IconX } from "@tabler/icons-react";
-import { cn } from "@/lib/utils";
 import { OPEN_NAV_USERNAME_EVENT } from "@/lib/events";
+import { Alert, AlertDescription, AlertTitle, AlertAction } from "./ui/alert";
+import { AlertCircleIcon, CheckCircle2Icon, InfoIcon } from "lucide-react";
+import { IconX } from "@tabler/icons-react";
+import { Button } from "./ui/button";
+import { cn } from "@/lib/utils";
 
 function focusInput(inputId: string) {
-  const usernameInput = document.getElementById(inputId) as HTMLInputElement | null;
+  const usernameInput = document.getElementById(
+    inputId,
+  ) as HTMLInputElement | null;
   if (!usernameInput) return;
   if (usernameInput.offsetParent === null) return;
   usernameInput.focus();
@@ -21,70 +26,112 @@ function focusUsernameInput() {
   window.dispatchEvent(new Event(OPEN_NAV_USERNAME_EVENT));
 }
 
-type UsernameFetchNoticeProps = {
-  showPrompt?: boolean;
-  icon?: ReactNode;
+export type UsernameFetchNoticeState = "info" | "error" | "success";
+
+type UsernameFetchNoticeBaseProps = {
   className?: string;
-  resetKey?: string | number | boolean;
   dismissLabel?: string;
-  children?: ReactNode;
+  resetKey?: string | number | boolean;
 };
 
-export function UsernameFetchNotice({
-  showPrompt = true,
-  icon,
-  className,
-  resetKey,
-  dismissLabel = "Dismiss requirements notice",
-  children,
-}: UsernameFetchNoticeProps) {
+type UsernameFetchNoticeProps =
+  | (UsernameFetchNoticeBaseProps & {
+      state: "info";
+    })
+  | (UsernameFetchNoticeBaseProps & {
+      state: "error";
+      children: ReactNode;
+    })
+  | (UsernameFetchNoticeBaseProps & {
+      state: "success";
+    });
+
+const noticeToneClassByState: Record<UsernameFetchNoticeState, string> = {
+  info: "border-sky-300/70 bg-sky-50 text-sky-900 dark:border-sky-900/45 dark:bg-sky-950/25 dark:text-sky-100",
+  error:
+    "border-rose-300/70 bg-rose-50 text-rose-900 dark:border-rose-900/45 dark:bg-rose-950/25 dark:text-rose-100",
+  success:
+    "border-emerald-300/70 bg-emerald-50 text-emerald-900 dark:border-emerald-900/45 dark:bg-emerald-950/25 dark:text-emerald-100",
+};
+
+type NoticeContent = {
+  icon: ReactNode;
+  title: string;
+  description: ReactNode;
+  action?: ReactNode;
+};
+
+function getNoticeContent(state: UsernameFetchNoticeState): NoticeContent {
+  if (state === "info") {
+    return {
+      icon: <InfoIcon />,
+      title: "Fetch username",
+      description:
+        "Enter your OSRS username to fetch your user data and filter methods by your stats.",
+      action: (
+        <Button onClick={focusUsernameInput} size="sm" variant="default">
+          Fetch user data
+        </Button>
+      ),
+    };
+  }
+
+  if (state === "success") {
+    return {
+      icon: <CheckCircle2Icon />,
+      title: "All requirements met",
+      description:
+        "Congratulations! Your character meets all the requirements to do this method.",
+    };
+  }
+
+  return {
+    icon: <AlertCircleIcon />,
+    title: "Requirements not met",
+    description: "",
+  };
+}
+
+export function UsernameFetchNotice(props: UsernameFetchNoticeProps) {
+  const {
+    state,
+    className,
+    dismissLabel = "Dismiss username notice",
+    resetKey,
+  } = props;
   const [isDismissed, setIsDismissed] = useState(false);
 
   useEffect(() => {
     setIsDismissed(false);
-  }, [resetKey]);
+  }, [state, resetKey]);
 
   if (isDismissed) return null;
-  if (!showPrompt && !children) return null;
+
+  const noticeContent = getNoticeContent(state);
+  const body = state === "error" ? props.children : noticeContent.description;
 
   return (
-    <div
+    <Alert
       className={cn(
-        "rounded-md border border-gray-300 bg-gray-200 p-4 text-sm dark:border-gray-700 dark:bg-gray-800",
+        "pr-10 has-data-[slot=alert-action]:pr-30",
+        noticeToneClassByState[state],
         className,
       )}
     >
-      <div className="flex items-start gap-4">
-        <span className="mt-0.5 inline-flex rounded-full border border-gray-300 bg-white p-1.5 text-muted-foreground dark:border-gray-600 dark:bg-gray-900/40">
-          {icon ?? <IconInfoCircle className="size-4" />}
-        </span>
-
-        <div className="min-w-0 flex-1 space-y-3">
-          {showPrompt ? (
-            <p className="text-gray-700 dark:text-gray-200">
-              Please{" "}
-              <button
-                type="button"
-                className="cursor-pointer underline"
-                onClick={focusUsernameInput}
-              >
-                enter your username
-              </button>{" "}
-              to fetch your user data.
-            </p>
-          ) : null}
-          {children}
-        </div>
-
-        <button
-          type="button"
-          onClick={() => setIsDismissed(true)}
-          aria-label={dismissLabel}
-          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md border border-gray-300 bg-white text-muted-foreground transition-colors hover:bg-gray-100 hover:text-foreground dark:border-gray-600 dark:bg-gray-900/40 dark:hover:bg-gray-900"
-        >
-          <IconX className="size-4" />
-        </button>
-      </div>
-    </div>
+      {noticeContent.icon}
+      <AlertTitle>{noticeContent.title}</AlertTitle>
+      <AlertDescription>{body}</AlertDescription>
+      {noticeContent.action ? (
+        <AlertAction className="right-10">{noticeContent.action}</AlertAction>
+      ) : null}
+      <button
+        type="button"
+        aria-label={dismissLabel}
+        onClick={() => setIsDismissed(true)}
+        className="absolute top-2 right-2 inline-flex size-7 items-center justify-center rounded-md text-current/70 transition-colors hover:bg-black/8 hover:text-current"
+      >
+        <IconX className="size-4" />
+      </button>
+    </Alert>
   );
 }

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "grid gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 group/alert relative w-full",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/src/features/method-detail/MethodVariantContent.tsx
+++ b/src/features/method-detail/MethodVariantContent.tsx
@@ -1,8 +1,6 @@
 import { Fragment, lazy, Suspense, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
-  IconAlertTriangle,
-  IconCircleCheck,
   IconClick,
   IconInfoCircle,
   IconTrendingDown,
@@ -326,38 +324,31 @@ function MissingRequirementsNotice({
   variant: Variant;
   username?: string;
 }) {
+  const normalizedUsername = username?.trim();
+  const hasUsername = Boolean(normalizedUsername);
   const hasMissingRequirements = Boolean(variant.missingRequirements);
-  const allRequirementsMet = Boolean(username) && !hasMissingRequirements;
-  const statusIcon = hasMissingRequirements ? (
-    <IconAlertTriangle className="size-4" />
-  ) : allRequirementsMet ? (
-    <IconCircleCheck className="size-4" />
-  ) : (
-    <IconInfoCircle className="size-4" />
+  const stickyNoticeClass = cn(
+    !hasUsername || hasMissingRequirements ? "lg:sticky lg:top-24 lg:z-10" : "",
   );
 
-  return (
-    <UsernameFetchNotice
-      showPrompt={!username}
-      icon={statusIcon}
-      resetKey={`${variant.id}-${username ?? "missing"}-${
-        hasMissingRequirements ? "missing" : "complete"
-      }`}
-      dismissLabel="Dismiss requirements notice"
-      className={cn(!allRequirementsMet && "lg:sticky lg:top-24 lg:z-10")}
-    >
-      {hasMissingRequirements ? (
+  if (!hasUsername) {
+    return <UsernameFetchNotice state="info" className={stickyNoticeClass} />;
+  }
+
+  if (hasMissingRequirements) {
+    return (
+      <UsernameFetchNotice state="error" className={stickyNoticeClass}>
         <div className="space-y-3">
           <p>You are missing some requirements to do this method:</p>
           <div className="flex flex-start flex-wrap gap-2">
             <LevelsAndQuestBadges requirement={variant.missingRequirements} />
           </div>
         </div>
-      ) : username ? (
-        <p>All requirements met!</p>
-      ) : null}
-    </UsernameFetchNotice>
-  );
+      </UsernameFetchNotice>
+    );
+  }
+
+  return <UsernameFetchNotice state="success" />;
 }
 
 function MetricsCards({ variant }: { variant: Variant }) {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -194,10 +194,7 @@ export function Home({ lockedSkill, pageTitle, seo }: Props) {
     <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto p-8 space-y-6">
         {!normalizedUsername ? (
-          <UsernameFetchNotice
-            resetKey={Boolean(normalizedUsername)}
-            className="sticky top-20 z-20"
-          />
+          <UsernameFetchNotice state="info" className="sticky top-20 z-20" />
         ) : null}
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <h1 className="text-3xl font-bold">{pageTitle ?? "All Methods"}</h1>


### PR DESCRIPTION
## Summary
- Add reusable `Alert` UI primitives (`Alert`, `AlertTitle`, `AlertDescription`, `AlertAction`) to standardize notice structure and actions.
- Refactor `UsernameFetchNotice` to a state-driven API (`info | error | success`) with centralized copy/icon mapping and a consistent dismiss control.
- Update notice consumers in Home and Method Detail to map username/requirements into explicit states and keep behavior aligned across the three scenarios.

## How to test
- `npm run lint`
- `npm test`
- `npm run build`
- Manual checks:
  - In Home, with no username set, verify the info notice appears with fetch action and dismiss `X`.
  - In Method Detail, with no username, verify the info notice is shown.
  - In Method Detail, with missing requirements, verify the error notice is shown with missing requirement badges.
  - In Method Detail, with requirements met, verify the success notice is shown.

## Notes
- No business logic changes.
