### PR TITLE
feat(method-form): add untradeables filters to item selectors

### DIFF
--- a/src/components/IoItemsField.tsx
+++ b/src/components/IoItemsField.tsx
@@ -34,8 +34,18 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
-import { IconGripVertical, IconX } from "@tabler/icons-react";
+import { Switch } from "@/components/ui/switch";
+import {
+  IconAdjustmentsHorizontal,
+  IconGripVertical,
+  IconX,
+} from "@tabler/icons-react";
 import { cn } from "@/lib/utils";
 
 const SEARCH_LIMIT = 10;
@@ -81,6 +91,7 @@ export function IoItemsField({
   const [currentPage, setCurrentPage] = useState(0);
   const [hasMoreResults, setHasMoreResults] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showUntradeables, setShowUntradeables] = useState(false);
   const [itemsMap, setItemsMap] = useState<Record<number, Item>>({});
   const [searchCache, setSearchCache] = useState<
     Record<number, ItemSearchResult>
@@ -151,7 +162,9 @@ export function IoItemsField({
     setResults([]);
 
     const timeout = setTimeout(() => {
-      searchItems(trimmed, SEARCH_LIMIT, 1, controller.signal)
+      searchItems(trimmed, SEARCH_LIMIT, 1, controller.signal, {
+        showUntradeables,
+      })
         .then((response) => {
           if (requestIdRef.current !== requestId) return;
           const nextItems = response.items.slice(0, SEARCH_LIMIT);
@@ -186,7 +199,7 @@ export function IoItemsField({
       controller.abort();
       clearTimeout(timeout);
     };
-  }, [query]);
+  }, [query, showUntradeables]);
 
   const loadMoreResults = useCallback(() => {
     const trimmed = query.trim();
@@ -200,7 +213,9 @@ export function IoItemsField({
     setLoadingMore(true);
     setError(null);
 
-    searchItems(trimmed, SEARCH_LIMIT, nextPage, controller.signal)
+    searchItems(trimmed, SEARCH_LIMIT, nextPage, controller.signal, {
+      showUntradeables,
+    })
       .then((response) => {
         if (requestIdRef.current !== requestId) return;
         const nextItems = response.items.slice(0, SEARCH_LIMIT);
@@ -243,7 +258,14 @@ export function IoItemsField({
           loadMoreControllerRef.current = null;
         }
       });
-  }, [currentPage, hasMoreResults, loading, loadingMore, query]);
+  }, [
+    currentPage,
+    hasMoreResults,
+    loading,
+    loadingMore,
+    query,
+    showUntradeables,
+  ]);
 
   const handleResultsScroll = useCallback(
     (event: UIEvent<HTMLElement>) => {
@@ -349,73 +371,102 @@ export function IoItemsField({
   return (
     <div className="space-y-3">
       <label className="block text-sm font-medium">{label}</label>
-      <Combobox<ItemSearchResult>
-        inputValue={query}
-        onInputValueChange={(value) => setQuery(value)}
-        onValueChange={(value) => handleAddItem(value)}
-        filter={null}
-        itemToStringLabel={(item) => item.name}
-        itemToStringValue={(item) => item.id.toString()}
-        isItemEqualToValue={(a, b) => {
-          if (!a || !b) return false;
-          return a.id === b.id;
-        }}
-      >
-        <ComboboxInput
-          className="w-full"
-          placeholder={placeholder ?? "Buscar item..."}
-          showClear={query.trim().length > 0}
-        />
-        <ComboboxContent>
-          <ComboboxList onScroll={handleResultsScroll}>
-            {loading && results.length === 0
-              ? Array.from({ length: 6 }).map((_, index) => (
-                  <div key={`item-search-skeleton-${index}`} className="px-2 py-1.5">
-                    <div className="flex items-center gap-2">
-                      <Skeleton className="h-[30px] w-[30px]" />
-                      <Skeleton className="h-4 w-44" />
-                    </div>
-                  </div>
-                ))
-              : results.map((item) => {
-                  const isAdded = items.some((entry) => entry.id === item.id);
-                  return (
-                    <ComboboxItem key={item.id} value={item} disabled={isAdded}>
+      <div className="flex items-start gap-2">
+        <Combobox<ItemSearchResult>
+          inputValue={query}
+          onInputValueChange={(value) => setQuery(value)}
+          onValueChange={(value) => handleAddItem(value)}
+          filter={null}
+          itemToStringLabel={(item) => item.name}
+          itemToStringValue={(item) => item.id.toString()}
+          isItemEqualToValue={(a, b) => {
+            if (!a || !b) return false;
+            return a.id === b.id;
+          }}
+        >
+          <ComboboxInput
+            className="w-full"
+            placeholder={placeholder ?? "Buscar item..."}
+            showClear={query.trim().length > 0}
+          />
+          <ComboboxContent>
+            <ComboboxList onScroll={handleResultsScroll}>
+              {loading && results.length === 0
+                ? Array.from({ length: 6 }).map((_, index) => (
+                    <div
+                      key={`item-search-skeleton-${index}`}
+                      className="px-2 py-1.5"
+                    >
                       <div className="flex items-center gap-2">
-                        {item.iconUrl ? (
-                          <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
-                            <img
-                              src={item.iconUrl}
-                              alt={item.name}
-                              className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
-                            />
-                          </div>
-                        ) : null}
-                        <span>{item.name}</span>
-                        {isAdded ? (
-                          <span className="text-xs text-muted-foreground">
-                            Agregado
-                          </span>
-                        ) : null}
+                        <Skeleton className="h-[30px] w-[30px]" />
+                        <Skeleton className="h-4 w-44" />
                       </div>
-                    </ComboboxItem>
-                  );
-                })}
-            {loadingMore ? (
-              <div className="px-2 py-1.5">
-                <div className="flex items-center gap-2">
-                  <Skeleton className="h-[30px] w-[30px]" />
-                  <Skeleton className="h-4 w-36" />
+                    </div>
+                  ))
+                : results.map((item) => {
+                    const isAdded = items.some((entry) => entry.id === item.id);
+                    return (
+                      <ComboboxItem key={item.id} value={item} disabled={isAdded}>
+                        <div className="flex items-center gap-2">
+                          {item.iconUrl ? (
+                            <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
+                              <img
+                                src={item.iconUrl}
+                                alt={item.name}
+                                className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
+                              />
+                            </div>
+                          ) : null}
+                          <span>{item.name}</span>
+                          {isAdded ? (
+                            <span className="text-xs text-muted-foreground">
+                              Agregado
+                            </span>
+                          ) : null}
+                        </div>
+                      </ComboboxItem>
+                    );
+                  })}
+              {loadingMore ? (
+                <div className="px-2 py-1.5">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-[30px] w-[30px]" />
+                    <Skeleton className="h-4 w-36" />
+                  </div>
                 </div>
-              </div>
+              ) : null}
+            </ComboboxList>
+            <ComboboxEmpty>{emptyMessage}</ComboboxEmpty>
+            {error ? (
+              <div className="px-2 py-1 text-xs text-destructive">{error}</div>
             ) : null}
-          </ComboboxList>
-          <ComboboxEmpty>{emptyMessage}</ComboboxEmpty>
-          {error ? (
-            <div className="px-2 py-1 text-xs text-destructive">{error}</div>
-          ) : null}
-        </ComboboxContent>
-      </Combobox>
+          </ComboboxContent>
+        </Combobox>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              aria-label={`${label} search options`}
+              className="shrink-0"
+            >
+              <IconAdjustmentsHorizontal size={16} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-64">
+            <div className="flex items-center justify-between gap-3 px-2 py-1.5">
+              <span className="text-sm">Show untradeables</span>
+              <Switch
+                checked={showUntradeables}
+                onCheckedChange={setShowUntradeables}
+                aria-label="Show untradeables"
+              />
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
 
       <Table className="rounded-md border">
         <TableHeader>

--- a/src/components/ItemSearchUntradeables.test.tsx
+++ b/src/components/ItemSearchUntradeables.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IoItemsField } from "@/components/IoItemsField";
+import { RequirementsRecommendationsField } from "@/components/RequirementsRecommendationsField";
+import { fetchItems, searchItems } from "@/lib/api";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    fetchItems: vi.fn(),
+    searchItems: vi.fn(),
+  };
+});
+
+describe("item search untradeables toggle", () => {
+  beforeEach(() => {
+    vi.mocked(fetchItems).mockResolvedValue({});
+    vi.mocked(searchItems).mockResolvedValue({
+      items: [],
+      page: 1,
+      pageCount: 1,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults to false and updates the inputs search request when enabled", async () => {
+    const user = userEvent.setup();
+
+    render(<IoItemsField label="Inputs" items={[]} onChange={vi.fn()} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Inputs search options" })
+    );
+
+    const showUntradeablesSwitch = await screen.findByRole("switch", {
+      name: "Show untradeables",
+    });
+    expect(showUntradeablesSwitch).toHaveAttribute("aria-checked", "false");
+
+    await user.click(showUntradeablesSwitch);
+    expect(showUntradeablesSwitch).toHaveAttribute("aria-checked", "true");
+    await user.keyboard("{Escape}");
+
+    const searchInput = screen.getByPlaceholderText("Buscar item...");
+    await user.type(searchInput, "coal");
+
+    await waitFor(() => expect(searchItems).toHaveBeenCalled());
+    expect(vi.mocked(searchItems).mock.calls.at(-1)?.[0]).toBe("coal");
+    expect(vi.mocked(searchItems).mock.calls.at(-1)?.[4]).toEqual({
+      showUntradeables: true,
+    });
+  });
+
+  it("defaults to false and updates requirements item search when enabled", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RequirementsRecommendationsField
+        requirements={{}}
+        recommendations={{}}
+        skillOptions={[]}
+        questOptions={[]}
+        achievementDiaryOptions={[]}
+        onChange={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Requirements search options" })
+    );
+
+    const showUntradeablesSwitch = await screen.findByRole("switch", {
+      name: "Show untradeables",
+    });
+    expect(showUntradeablesSwitch).toHaveAttribute("aria-checked", "false");
+
+    await user.click(showUntradeablesSwitch);
+    expect(showUntradeablesSwitch).toHaveAttribute("aria-checked", "true");
+    await user.keyboard("{Escape}");
+
+    const searchInput = screen.getByPlaceholderText(
+      "Buscar items, quests, achievement diaries o skills..."
+    );
+    await user.type(searchInput, "coal");
+
+    await waitFor(() => expect(searchItems).toHaveBeenCalled());
+    expect(vi.mocked(searchItems).mock.calls.at(-1)?.[0]).toBe("coal");
+    expect(vi.mocked(searchItems).mock.calls.at(-1)?.[4]).toEqual({
+      showUntradeables: true,
+    });
+  });
+});

--- a/src/components/RequirementsRecommendationsField.tsx
+++ b/src/components/RequirementsRecommendationsField.tsx
@@ -18,6 +18,8 @@ export function RequirementsRecommendationsField(
         query={state.query}
         onQueryChange={state.setQuery}
         onSelectOption={state.handleSelectOption}
+        showUntradeables={state.showUntradeables}
+        onShowUntradeablesChange={state.setShowUntradeables}
         visibleSearchGroups={state.visibleSearchGroups}
         selectedEntryKeys={state.selectedEntryKeys}
         emptyMessage={state.emptyMessage}

--- a/src/components/requirements-recommendations/RequirementsSearchCombobox.tsx
+++ b/src/components/requirements-recommendations/RequirementsSearchCombobox.tsx
@@ -1,5 +1,6 @@
 import { Fragment, type UIEvent } from "react";
 import { getUrlByType } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import {
   Combobox,
   ComboboxContent,
@@ -11,7 +12,14 @@ import {
   ComboboxList,
   ComboboxSeparator,
 } from "@/components/ui/combobox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
 import type {
   SearchOption,
   SearchOptionGroup,
@@ -21,6 +29,8 @@ interface RequirementsSearchComboboxProps {
   query: string;
   onQueryChange: (value: string) => void;
   onSelectOption: (value: SearchOption | null) => void;
+  showUntradeables: boolean;
+  onShowUntradeablesChange: (checked: boolean) => void;
   visibleSearchGroups: SearchOptionGroup[];
   selectedEntryKeys: Set<string>;
   emptyMessage: string;
@@ -36,6 +46,8 @@ export function RequirementsSearchCombobox({
   query,
   onQueryChange,
   onSelectOption,
+  showUntradeables,
+  onShowUntradeablesChange,
   visibleSearchGroups,
   selectedEntryKeys,
   emptyMessage,
@@ -47,115 +59,145 @@ export function RequirementsSearchCombobox({
   achievementDiaryIconUrl,
 }: RequirementsSearchComboboxProps) {
   return (
-    <Combobox<SearchOption>
-      inputValue={query}
-      onInputValueChange={onQueryChange}
-      onValueChange={onSelectOption}
-      filter={null}
-      itemToStringLabel={(item) => item.label}
-      itemToStringValue={(item) => item.key}
-      isItemEqualToValue={(left, right) => {
-        if (!left || !right) return false;
-        return left.key === right.key;
-      }}
-    >
-      <ComboboxInput
-        className="w-full"
-        placeholder="Buscar items, quests, achievement diaries o skills..."
-        showClear={query.trim().length > 0}
-      />
-      <ComboboxContent>
-        <ComboboxList onScroll={onSearchListScroll}>
-          {visibleSearchGroups.map((group, groupIndex) => (
-            <Fragment key={group.id}>
-              {groupIndex > 0 ? <ComboboxSeparator /> : null}
-              <ComboboxGroup>
-                <ComboboxLabel>{group.label}</ComboboxLabel>
-                {group.options.map((option) => {
-                  const isAdded = selectedEntryKeys.has(option.entryKey);
-                  const skillIconUrl =
-                    option.kind === "skill" ? getUrlByType(option.skill) : null;
-                  return (
-                    <ComboboxItem key={option.key} value={option} disabled={isAdded}>
-                      <div className="flex items-center gap-2">
-                        {option.kind === "item" && option.iconUrl ? (
-                          <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
-                            <img
-                              src={option.iconUrl}
-                              alt={option.label}
-                              className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
-                            />
-                          </div>
-                        ) : null}
-                        {option.kind === "skill" && skillIconUrl ? (
-                          <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
-                            <img
-                              src={skillIconUrl}
-                              alt={`${option.skill}_icon`}
-                              className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
-                            />
-                          </div>
-                        ) : null}
-                        {option.kind === "quest" && questIconUrl ? (
-                          <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
-                            <img
-                              src={questIconUrl}
-                              alt="quests_icon"
-                              className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
-                            />
-                          </div>
-                        ) : null}
-                        {option.kind === "achievement_diary" &&
-                        achievementDiaryIconUrl ? (
-                          <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
-                            <img
-                              src={achievementDiaryIconUrl}
-                              alt="achievement_diaries_icon"
-                              className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
-                            />
-                          </div>
-                        ) : null}
-                        <span>{option.label}</span>
-                        {isAdded ? (
-                          <span className="text-xs text-muted-foreground">Agregado</span>
-                        ) : null}
-                      </div>
-                    </ComboboxItem>
-                  );
-                })}
-              </ComboboxGroup>
-            </Fragment>
-          ))}
-          {itemSearchLoading ? (
-            <div className="px-2 py-1.5">
-              <Skeleton className="mb-2 h-3 w-24" />
-              <div className="space-y-1.5">
-                {Array.from({ length: 4 }).map((_, index) => (
-                  <div
-                    key={`requirements-item-skeleton-${index}`}
-                    className="flex items-center gap-2"
-                  >
-                    <Skeleton className="h-[30px] w-[30px]" />
-                    <Skeleton className="h-4 w-48" />
-                  </div>
-                ))}
+    <div className="flex items-start gap-2">
+      <Combobox<SearchOption>
+        inputValue={query}
+        onInputValueChange={onQueryChange}
+        onValueChange={onSelectOption}
+        filter={null}
+        itemToStringLabel={(item) => item.label}
+        itemToStringValue={(item) => item.key}
+        isItemEqualToValue={(left, right) => {
+          if (!left || !right) return false;
+          return left.key === right.key;
+        }}
+      >
+        <ComboboxInput
+          className="w-full"
+          placeholder="Buscar items, quests, achievement diaries o skills..."
+          showClear={query.trim().length > 0}
+        />
+        <ComboboxContent>
+          <ComboboxList onScroll={onSearchListScroll}>
+            {visibleSearchGroups.map((group, groupIndex) => (
+              <Fragment key={group.id}>
+                {groupIndex > 0 ? <ComboboxSeparator /> : null}
+                <ComboboxGroup>
+                  <ComboboxLabel>{group.label}</ComboboxLabel>
+                  {group.options.map((option) => {
+                    const isAdded = selectedEntryKeys.has(option.entryKey);
+                    const skillIconUrl =
+                      option.kind === "skill" ? getUrlByType(option.skill) : null;
+                    return (
+                      <ComboboxItem key={option.key} value={option} disabled={isAdded}>
+                        <div className="flex items-center gap-2">
+                          {option.kind === "item" && option.iconUrl ? (
+                            <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
+                              <img
+                                src={option.iconUrl}
+                                alt={option.label}
+                                className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
+                              />
+                            </div>
+                          ) : null}
+                          {option.kind === "skill" && skillIconUrl ? (
+                            <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
+                              <img
+                                src={skillIconUrl}
+                                alt={`${option.skill}_icon`}
+                                className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
+                              />
+                            </div>
+                          ) : null}
+                          {option.kind === "quest" && questIconUrl ? (
+                            <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
+                              <img
+                                src={questIconUrl}
+                                alt="quests_icon"
+                                className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
+                              />
+                            </div>
+                          ) : null}
+                          {option.kind === "achievement_diary" &&
+                          achievementDiaryIconUrl ? (
+                            <div className="flex h-[30px] w-[30px] shrink-0 items-center justify-center">
+                              <img
+                                src={achievementDiaryIconUrl}
+                                alt="achievement_diaries_icon"
+                                className="h-auto w-auto max-h-full max-w-full object-contain [image-rendering:pixelated]"
+                              />
+                            </div>
+                          ) : null}
+                          <span>{option.label}</span>
+                          {isAdded ? (
+                            <span className="text-xs text-muted-foreground">
+                              Agregado
+                            </span>
+                          ) : null}
+                        </div>
+                      </ComboboxItem>
+                    );
+                  })}
+                </ComboboxGroup>
+              </Fragment>
+            ))}
+            {itemSearchLoading ? (
+              <div className="px-2 py-1.5">
+                <Skeleton className="mb-2 h-3 w-24" />
+                <div className="space-y-1.5">
+                  {Array.from({ length: 4 }).map((_, index) => (
+                    <div
+                      key={`requirements-item-skeleton-${index}`}
+                      className="flex items-center gap-2"
+                    >
+                      <Skeleton className="h-[30px] w-[30px]" />
+                      <Skeleton className="h-4 w-48" />
+                    </div>
+                  ))}
+                </div>
               </div>
+            ) : null}
+            {itemSearchLoadingMore ? (
+              <div className="px-2 py-1.5">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-[30px] w-[30px]" />
+                  <Skeleton className="h-4 w-40" />
+                </div>
+              </div>
+            ) : null}
+          </ComboboxList>
+          <ComboboxEmpty>{emptyMessage}</ComboboxEmpty>
+          {itemSearchError ? (
+            <div className="px-2 py-1 text-xs text-destructive">
+              {itemSearchError}
             </div>
           ) : null}
-          {itemSearchLoadingMore ? (
-            <div className="px-2 py-1.5">
-              <div className="flex items-center gap-2">
-                <Skeleton className="h-[30px] w-[30px]" />
-                <Skeleton className="h-4 w-40" />
-              </div>
-            </div>
-          ) : null}
-        </ComboboxList>
-        <ComboboxEmpty>{emptyMessage}</ComboboxEmpty>
-        {itemSearchError ? (
-          <div className="px-2 py-1 text-xs text-destructive">{itemSearchError}</div>
-        ) : null}
-      </ComboboxContent>
-    </Combobox>
+        </ComboboxContent>
+      </Combobox>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            aria-label="Requirements search options"
+            className="shrink-0"
+          >
+            <IconAdjustmentsHorizontal size={16} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-64">
+          <div className="flex items-center justify-between gap-3 px-2 py-1.5">
+            <span className="text-sm">Show untradeables</span>
+            <Switch
+              checked={showUntradeables}
+              onCheckedChange={onShowUntradeablesChange}
+              aria-label="Show untradeables"
+            />
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }

--- a/src/components/requirements-recommendations/useRequirementsRecommendations.ts
+++ b/src/components/requirements-recommendations/useRequirementsRecommendations.ts
@@ -50,6 +50,8 @@ type EntryUpdater = (entry: UnifiedEntry) => UnifiedEntry;
 export interface UseRequirementsRecommendationsResult {
   query: string;
   setQuery: (value: string) => void;
+  showUntradeables: boolean;
+  setShowUntradeables: (value: boolean) => void;
   emptyMessage: string;
   itemSearchError: string | null;
   itemSearchLoading: boolean;
@@ -79,6 +81,7 @@ export function useRequirementsRecommendations({
   onChange,
 }: RequirementsRecommendationsFieldProps): UseRequirementsRecommendationsResult {
   const [query, setQuery] = useState("");
+  const [showUntradeables, setShowUntradeables] = useState(false);
   const [entries, setEntries] = useState<UnifiedEntry[]>(() =>
     buildUnifiedEntries(requirements, recommendations)
   );
@@ -191,7 +194,9 @@ export function useRequirementsRecommendations({
     setItemSearchResults([]);
 
     const timeout = setTimeout(() => {
-      searchItems(trimmedQuery, ITEM_SEARCH_LIMIT, 1, controller.signal)
+      searchItems(trimmedQuery, ITEM_SEARCH_LIMIT, 1, controller.signal, {
+        showUntradeables,
+      })
         .then((response) => {
           if (itemSearchRequestIdRef.current !== requestId) return;
           const nextItems = response.items.slice(0, ITEM_SEARCH_LIMIT);
@@ -226,7 +231,7 @@ export function useRequirementsRecommendations({
       controller.abort();
       clearTimeout(timeout);
     };
-  }, [query]);
+  }, [query, showUntradeables]);
 
   const loadMoreItemSearchResults = useCallback(() => {
     const trimmedQuery = query.trim();
@@ -246,7 +251,9 @@ export function useRequirementsRecommendations({
     setItemSearchLoadingMore(true);
     setItemSearchError(null);
 
-    searchItems(trimmedQuery, ITEM_SEARCH_LIMIT, nextPage, controller.signal)
+    searchItems(trimmedQuery, ITEM_SEARCH_LIMIT, nextPage, controller.signal, {
+      showUntradeables,
+    })
       .then((response) => {
         if (itemSearchRequestIdRef.current !== requestId) return;
         const nextItems = response.items.slice(0, ITEM_SEARCH_LIMIT);
@@ -295,6 +302,7 @@ export function useRequirementsRecommendations({
     itemSearchLoadingMore,
     itemSearchPage,
     query,
+    showUntradeables,
   ]);
 
   const handleSearchListScroll = useCallback(
@@ -607,6 +615,8 @@ export function useRequirementsRecommendations({
   return {
     query,
     setQuery,
+    showUntradeables,
+    setShowUntradeables,
     emptyMessage,
     itemSearchError,
     itemSearchLoading,

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -3,6 +3,7 @@ import {
   buildMethodUpdatePayload,
   fetchItems,
   getVariantsSignature,
+  searchItems,
   type Variant,
 } from "./api";
 
@@ -74,6 +75,59 @@ describe("api update payload helpers", () => {
     expect(url.searchParams.get("fields")).toBe(
       "name,iconUrl,highPrice,lowPrice,high24h,low24h,highTime,lowTime"
     );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("defaults showUntradeables to false when searching items", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { items: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await searchItems("coal", 10, 2);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const requestInput = fetchSpy.mock.calls[0]?.[0];
+    const requestUrl =
+      typeof requestInput === "string"
+        ? requestInput
+        : requestInput instanceof URL
+          ? requestInput.toString()
+          : requestInput.url;
+    const url = new URL(requestUrl, window.location.origin);
+
+    expect(url.searchParams.get("q")).toBe("coal");
+    expect(url.searchParams.get("limit")).toBe("10");
+    expect(url.searchParams.get("page")).toBe("2");
+    expect(url.searchParams.get("showUntradeables")).toBe("false");
+
+    fetchSpy.mockRestore();
+  });
+
+  it("passes showUntradeables when enabled in item search", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: { items: [] } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    await searchItems("coal", 10, 1, undefined, { showUntradeables: true });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const requestInput = fetchSpy.mock.calls[0]?.[0];
+    const requestUrl =
+      typeof requestInput === "string"
+        ? requestInput
+        : requestInput instanceof URL
+          ? requestInput.toString()
+          : requestInput.url;
+    const url = new URL(requestUrl, window.location.origin);
+
+    expect(url.searchParams.get("showUntradeables")).toBe("true");
 
     fetchSpy.mockRestore();
   });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -380,6 +380,10 @@ export interface ItemSearchResponse {
   perPage?: number;
 }
 
+export interface ItemSearchOptions {
+  showUntradeables?: boolean;
+}
+
 export interface AchievementDiaryOption {
   label: string;
   value: string;
@@ -749,6 +753,7 @@ export async function searchItems(
   limit = 10,
   pageOrSignal?: number | AbortSignal,
   signal?: AbortSignal,
+  options?: ItemSearchOptions,
 ): Promise<ItemSearchResponse> {
   const trimmed = query.trim();
   if (!trimmed) return { items: [], page: 1, pageCount: 0 };
@@ -762,6 +767,10 @@ export async function searchItems(
   url.searchParams.set("q", trimmed);
   url.searchParams.set("limit", limit.toString());
   url.searchParams.set("page", page.toString());
+  url.searchParams.set(
+    "showUntradeables",
+    String(options?.showUntradeables ?? false),
+  );
   const res = await apiFetch(
     url.toString(),
     requestSignal ? { signal: requestSignal } : undefined,


### PR DESCRIPTION
## Summary
- Add `showUntradeables` support to item search requests and default it to `false`.
- Add a search options control for item selectors in inputs and outputs so untradeables can be toggled from the selector UI.
- Align the requirements and recommendations search combobox with the same options-button pattern for the untradeables filter.
- Add API and UI regression coverage for the new untradeables search toggle behavior.

## How to test
- `npm run lint`
- `npm test`
- `npm run build`
- Open the method form and verify the item search options button appears in inputs, outputs, and requirements/recommendations.
- Toggle `Show untradeables` and confirm subsequent item search requests include the expected `showUntradeables` query param.

## Notes
- This change updates frontend search request parameters and editor filtering controls.
